### PR TITLE
Update run_retrieval_eval.py for Windows compatibility

### DIFF
--- a/scripts/evaluation/run_retrieval_eval.py
+++ b/scripts/evaluation/run_retrieval_eval.py
@@ -83,7 +83,7 @@ def load_qrels(qrels_file):
 def prepare_results_dict(input_file):
     results = {}
     collection_results = {}
-    with open(input_file, 'r') as f:
+    with open(input_file, 'r', encoding='utf-8') as f:
         for line in f:
             item = json.loads(line)
             query_id = item["task_id"]
@@ -131,13 +131,13 @@ def main():
         print("\ncollection_name:", collection_name)
 
         if collection_name == "mt-rag-clapnq-elser-512-100-20240503":
-            qrels_file = os.path.join(script_dir, "../../human/retrieval_tasks_convid/clapnq/qrels/dev.tsv")
+            qrels_file = os.path.join(script_dir, "../../human/retrieval_tasks/clapnq/qrels/dev.tsv")
         if collection_name == "mt-rag-govt-elser-512-100-20240611":
-            qrels_file = os.path.join(script_dir, "../../human/retrieval_tasks_convid/govt/qrels/dev.tsv")
+            qrels_file = os.path.join(script_dir, "../../human/retrieval_tasks/govt/qrels/dev.tsv")
         if collection_name == "mt-rag-fiqa-beir-elser-512-100-20240501":
-            qrels_file = os.path.join(script_dir, "../../human/retrieval_tasks_convid/fiqa/qrels/dev.tsv")
+            qrels_file = os.path.join(script_dir, "../../human/retrieval_tasks/fiqa/qrels/dev.tsv")
         if collection_name == "mt-rag-ibmcloud-elser-512-100-20240502":
-            qrels_file = os.path.join(script_dir, "../../human/retrieval_tasks_convid/cloud/qrels/dev.tsv")
+            qrels_file = os.path.join(script_dir, "../../human/retrieval_tasks/cloud/qrels/dev.tsv")
             
         qrels = load_qrels(qrels_file)
         


### PR DESCRIPTION
- Add explicit UTF-8 encoding to file operations to prevent UnicodeDecodeError
- Correct directory path references as _convid is not included