### PR TITLE
fix incorrect run_radbench_judge invocation in generation evaluation

### DIFF
--- a/scripts/evaluation/run_generation_eval.py
+++ b/scripts/evaluation/run_generation_eval.py
@@ -77,13 +77,13 @@ if __name__ == "__main__":
     if args.provider == "openai":
         run_idk_judge(args.provider, "", args.output, args.output)
         run_ragas_judges_openai(args.output, args.output, args.openai_key, args.azure_host)
-        run_radbench_judge(args.provider, args.output, args.output)
+        run_radbench_judge(args.provider, "", args.output, args.output)
         
         get_idk_conditioned_metrics(args.output, args.output)
     else:
         run_idk_judge(args.provider, args.judge_model, args.output, args.output)
         
         run_ragas_judges_local(args.provider, judge_model, args.output, args.output)
-        run_radbench_judge(judge_model, args.output, args.output)
+        run_radbench_judge(args.provider, judge_model, args.output, args.output)
         
         get_idk_conditioned_metrics(args.output, args.output)


### PR DESCRIPTION
This PR fixes an argument mismatch when calling `run_radbench_judge()` in
`scripts/evaluation/run_generation_eval.py`.

The function signature expects four arguments:

```python
def run_radbench_judge(provider, judge_model, input_file, output_file):
```
However, the current code passes only three arguments which causes a runtime error during evaluation.

**Fix**

Update run_radbench_judge() calls to pass the correct number and order
of arguments.

Ensure provider and judge_model are consistently passed for all
providers (openai, hf, vllm).

**Impact**

Prevents TypeError: missing required positional argument: output_file

Restores generation evaluation for local (hf / vllm) judge models

No behavior change beyond fixing the broken call signature.

**Repro**
```
python scripts/evaluation/run_generation_eval.py \
  --provider vllm \
  --judge_model Qwen/Qwen3-4B \
  -i submission.jsonl \
  -o output.jsonl
```

