### PR TITLE
Add underspecified judge and metrics conditioning

### DIFF
--- a/scripts/evaluation/judge_wrapper.py
+++ b/scripts/evaluation/judge_wrapper.py
@@ -118,18 +118,47 @@ def get_idk_score(row, use_metric):
         return rl_f
     
     
+def get_idk_underspec_score(row, use_metric):
+    answerability_vals = row.get("answerability", [])
+    metrics = row.get("metrics", {})
+
+    answerability = answerability_vals[0] if answerability_vals else None
+
+    if answerability is None:
+        print("Error: answerability is None")
+    else:
+        print(answerability)
+
+    idk_eval = metrics.get("idk_eval")[0]
+    rl_f = metrics.get(use_metric)[0]
+    underspec_eval = metrics.get("underspecified_eval")[0]
+
+    if answerability in ["UNDERSPECIFIED"] and underspec_eval == 1:
+        return 1
+    elif answerability in ["UNDERSPECIFIED"] and underspec_eval != 1:
+        return 0
+    elif answerability in ["UNANSWERABLE", "CONVERSATIONAL"] and idk_eval == 1:
+        return 1
+    elif answerability in ["UNANSWERABLE", "CONVERSATIONAL"] and idk_eval in [0, 0.5]:
+        return 0
+    elif idk_eval == 1:
+        return 0
+    else:
+        return rl_f
+
+
 def get_idk_conditioned_metrics(input_file, output_file):
     model_predictions = read_json_with_pandas(filepath=f"{input_file}")
 
-    model_predictions['RL_F_idk'] = model_predictions.apply(get_idk_score, axis=1, use_metric = 'RL_F')
-    model_predictions['RB_llm_idk'] = model_predictions.apply(get_idk_score, axis=1, use_metric = 'RB_llm')
-    model_predictions['RB_agg_idk'] = model_predictions.apply(get_idk_score, axis=1, use_metric = 'RB_agg')
-    
-    model_predictions['metrics'] = model_predictions.apply(lambda row: update_or_create_dict(row.get('metrics'), row['RL_F_idk'], 'RL_F_idk'), axis=1)
-    model_predictions['metrics'] = model_predictions.apply(lambda row: update_or_create_dict(row.get('metrics'), row['RB_llm_idk'], 'RB_llm_idk'), axis=1)
-    model_predictions['metrics'] = model_predictions.apply(lambda row: update_or_create_dict(row.get('metrics'), row['RB_agg_idk'], 'RB_agg_idk'), axis=1)
+    model_predictions['RL_F_idk_underspecified'] = model_predictions.apply(get_idk_underspec_score, axis=1, use_metric = 'RL_F')
+    model_predictions['RB_llm_idk_underspecified'] = model_predictions.apply(get_idk_underspec_score, axis=1, use_metric = 'RB_llm')
+    model_predictions['RB_agg_idk_underspecified'] = model_predictions.apply(get_idk_underspec_score, axis=1, use_metric = 'RB_agg')
 
-    keys_to_remove = ["RL_F_idk", "RB_llm_idk", "RB_agg_idk"]
+    model_predictions['metrics'] = model_predictions.apply(lambda row: update_or_create_dict(row.get('metrics'), row['RL_F_idk_underspecified'], 'RL_F_idk_underspecified'), axis=1)
+    model_predictions['metrics'] = model_predictions.apply(lambda row: update_or_create_dict(row.get('metrics'), row['RB_llm_idk_underspecified'], 'RB_llm_idk_underspecified'), axis=1)
+    model_predictions['metrics'] = model_predictions.apply(lambda row: update_or_create_dict(row.get('metrics'), row['RB_agg_idk_underspecified'], 'RB_agg_idk_underspecified'), axis=1)
+
+    keys_to_remove = ["RL_F_idk_underspecified", "RB_llm_idk_underspecified", "RB_agg_idk_underspecified"]
     model_predictions = remove_keys_from_df(model_predictions, keys_to_remove)
 
     model_predictions.to_json(output_file, orient="records", lines=True)
@@ -300,6 +329,96 @@ def run_radbench_judge(provider, judge_model, input_file, output_file):
     keys_to_remove = ["inquiry", "document", "response", "reference_answer", "previous_conversation", "current_question", "RB_llm"]
     model_predictions = remove_keys_from_df(model_predictions, keys_to_remove)
     
+    model_predictions.to_json(output_file, orient="records", lines=True)
+
+# ================================================
+# Helper function for JSON extraction
+# ================================================
+def remove_invalid_escapes(s: str):
+    import re
+    pattern = r'\\(?![\"\\/bfnrt]|u[0-9a-fA-F]{4})'
+    return re.sub(pattern, '', s)
+
+def extract_and_format_json(raw_text: str):
+    import re
+    import json
+
+    if "```json" in raw_text:
+        pat = r"```json\s*(.*?)\s*```"
+    else:
+        pat = r"\{\s*(.*?)\s*\}"
+    match = re.search(pat, raw_text, re.DOTALL)
+    if not match:
+        raise ValueError("Check clarification, no valid JSON fenced by {} was found.")
+
+    json_string = match.group(1)
+    cleaned_json_string = remove_invalid_escapes(json_string)
+    if not cleaned_json_string.startswith("{"):
+        cleaned_json_string = "{" + cleaned_json_string
+    if not cleaned_json_string.endswith("}"):
+        cleaned_json_string = cleaned_json_string + "}"
+
+    try:
+        parsed = json.loads(cleaned_json_string)
+    except json.JSONDecodeError as e:
+        raise ValueError(f"Check clarification, invalid JSON format after cleaning: {e}")
+
+    return parsed
+
+# ================================================
+# Run Underspecified Judge
+# ================================================
+def underspecified_eval(model_name, input_file, output_file):
+    from underspecified_eval import format_underspecified_judge
+
+    if model_name == "openai":
+        client = AzureOpenAIClient('gpt-4o-mini-2024-07-18')
+    else:
+        clear_cuda()
+        llm_model = load_chat_openai_llm(model_name)
+
+    model_predictions = read_json_with_pandas(filepath=f"{input_file}")
+
+    model_predictions['inquiry'] = model_predictions['input'].apply(extract_conversation)
+    model_predictions['response'] = model_predictions['predictions'].apply(extract_texts)
+
+    formatted_conversations = format_underspecified_judge(model_predictions)
+
+    response_lst = []
+    for cur_prompt in tqdm(formatted_conversations):
+        if model_name == "openai":
+            raw_text = client.generate_response(cur_prompt)
+        else:
+            response_obj = llm_model(cur_prompt)
+            raw_text = response_obj.content
+
+        try:
+            formatted_json = extract_and_format_json(raw_text)
+            print("Extracted JSON:", formatted_json)
+            decision = formatted_json.get("decision", "").lower()
+
+            if decision == "yes":
+                score = 1
+            elif decision == "no":
+                score = 0
+            else:
+                score = 0.5
+        except:
+            score = 0.5
+
+        response_lst.append(score)
+
+    model_predictions['underspecified_eval'] = response_lst
+
+    if 'metrics' not in model_predictions:
+        model_predictions['metrics'] = None
+
+    model_predictions['metrics'] = model_predictions.apply(
+        lambda row: update_or_create_dict(row.get('metrics'), row['underspecified_eval'], 'underspecified_eval'),
+        axis=1
+    )
+
+    model_predictions = remove_keys_from_df(model_predictions, ["inquiry", "response", "underspecified_eval"])
     model_predictions.to_json(output_file, orient="records", lines=True)
 
 # ================================================

--- a/scripts/evaluation/requirements.txt
+++ b/scripts/evaluation/requirements.txt
@@ -16,3 +16,4 @@ bitsandbytes==0.47.0
 flash_attn==2.8.3
 pydantic==2.11.7
 vllm==0.10.2
+jinja2

--- a/scripts/evaluation/run_generation_eval.py
+++ b/scripts/evaluation/run_generation_eval.py
@@ -64,28 +64,22 @@ if __name__ == "__main__":
     if args.provider == "openai":
         if not args.openai_key or not args.azure_host:
             parser.error("--provider openai requires --openai_key and --azure_host")
-            
+
         os.environ["AZURE_OPENAI_API_KEY"] = args.openai_key
         os.environ["OPENAI_AZURE_HOST"] = args.azure_host
+        model = "openai"
     else:
         if not args.judge_model:
             parser.error(f"--provider {args.provider} requires --judge_model")
+        model = args.judge_model
 
-        judge_model = args.judge_model
-    
-    
+    underspecified_eval(model, args.output, args.output)
+    run_idk_judge(args.provider, model if args.provider != "openai" else "", args.output, args.output)
+
     if args.provider == "openai":
-        underspecified_eval("openai", args.output, args.output)
-        run_idk_judge(args.provider, "", args.output, args.output)
         run_ragas_judges_openai(args.output, args.output, args.openai_key, args.azure_host)
-        run_radbench_judge(args.provider, "", args.output, args.output)
-
-        get_idk_conditioned_metrics(args.output, args.output)
     else:
-        underspecified_eval(args.judge_model, args.output, args.output)
-        run_idk_judge(args.provider, args.judge_model, args.output, args.output)
+        run_ragas_judges_local(args.provider, model, args.output, args.output)
 
-        run_ragas_judges_local(args.provider, judge_model, args.output, args.output)
-        run_radbench_judge(args.provider, judge_model, args.output, args.output)
-
-        get_idk_conditioned_metrics(args.output, args.output)
+    run_radbench_judge(args.provider, model if args.provider != "openai" else "", args.output, args.output)
+    get_idk_conditioned_metrics(args.output, args.output)

--- a/scripts/evaluation/run_generation_eval.py
+++ b/scripts/evaluation/run_generation_eval.py
@@ -75,15 +75,17 @@ if __name__ == "__main__":
     
     
     if args.provider == "openai":
+        underspecified_eval("openai", args.output, args.output)
         run_idk_judge(args.provider, "", args.output, args.output)
         run_ragas_judges_openai(args.output, args.output, args.openai_key, args.azure_host)
         run_radbench_judge(args.provider, "", args.output, args.output)
-        
+
         get_idk_conditioned_metrics(args.output, args.output)
     else:
+        underspecified_eval(args.judge_model, args.output, args.output)
         run_idk_judge(args.provider, args.judge_model, args.output, args.output)
-        
+
         run_ragas_judges_local(args.provider, judge_model, args.output, args.output)
         run_radbench_judge(args.provider, judge_model, args.output, args.output)
-        
+
         get_idk_conditioned_metrics(args.output, args.output)

--- a/scripts/evaluation/underspecified_eval.py
+++ b/scripts/evaluation/underspecified_eval.py
@@ -1,0 +1,54 @@
+from jinja2 import Template
+from judge_utils import *
+
+UNDERSPECIFIED_PROMPT = """
+    ## Role
+    You are an assistant that determines whether a given response is asking for clarification.
+
+    ## Input
+    A response. 
+
+    ## Definition
+    A clarification response is a response whose primary purpose is to request additional information needed to resolve an ambiguity, underspecification, or unclear reference in the user's original message.
+    
+    Clarification responses may appear in two forms:
+    1. **Direct clarification questions**  
+       – Explicit questions asking the user to specify or choose among options.  
+       Example: “Which one are you referring to?”
+    
+    2. **Directive clarification requests**  
+       – Imperative or polite statements that ask the user to *provide specific missing information*.  
+       – These still count even if they contain no question mark.  
+       Example: “Please provide the book you are referring to.”
+    
+    ## Not clarification responses:
+    - Statements that merely express inability to answer **without requesting the missing info**.  
+    - Responses that mention missing information but do **not** directly ask the user to provide it.  
+      Example: “I can't answer because I don't have your location.”  
+    - Responses that ask unrelated questions or introduce new topics.
+
+    ## Output format
+    Your output must be a single valid JSON object that adheres to the following structure:
+    ```json
+    {
+      "decision": "yes/no",
+      "explanation": "a brief explanation of why"
+    }
+    ```
+    
+    Response: 
+    {{ response }}
+
+    """
+
+def format_underspecified_judge(df):
+    template = Template(UNDERSPECIFIED_PROMPT)
+    
+    formatted_conversations = []
+    for index, row in df.iterrows():
+        inquiry, response = row['inquiry'], row['response']
+        prompt_template = template.render(response=response)
+        formatted_conversations.append(prompt_template)
+    
+    return formatted_conversations
+        


### PR DESCRIPTION
- Add `underspecified_eval()` judge that detects whether a model response is asking for clarification (for UNDERSPECIFIED questions).
- Add `underspecified_eval.py` with the judge prompt template (`format_underspecified_judge`).
- Replace `get_idk_conditioned_metrics` with an underspecified-aware version (`get_idk_underspec_score`) that handles `UNDERSPECIFIED` answerability